### PR TITLE
enforce opencv==4.7.0.72

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ matplotlib
 numpy
 scipy
 open3d
-opencv-contrib-python
+opencv-contrib-python==4.7.0.72
 OpenEXR
 pytest
 PyYAML


### PR DESCRIPTION
the last good (and best) version
wworks perfect with venv.

a newer python 3.12 doesn't have this opencv version yet. and 4.9 compat is in work. they changed the calib and objdetect backend completely into a more generic one. aruco is deprecated, a chessboard is enough.